### PR TITLE
Linode addons

### DIFF
--- a/addons/ccm-linode.yaml
+++ b/addons/ccm-linode.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ccm-linode
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: system:ccm-linode
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: ccm-linode
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ccm-linode
+  labels:
+    app: ccm-linode
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ccm-linode
+  template:
+    metadata:
+      labels:
+        app: ccm-linode
+    spec:
+      serviceAccountName: ccm-linode
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      containers:
+        - image: appscode/ccm-linode:external
+          imagePullPolicy: Always
+          name: ccm-linode
+          args:
+          - up
+          - --cloud-config=/etc/kubernetes/cloud-config
+          - --cloud-provider=linode
+          - --v=3
+          volumeMounts:
+          - mountPath: /etc/kubernetes
+            name: k8s
+          ports:
+            - containerPort: 9844
+              name: web
+              protocol: TCP
+      volumes:
+      - name: k8s
+        hostPath:
+          path: /etc/kubernetes

--- a/addons/ccm-linode.yaml
+++ b/addons/ccm-linode.yaml
@@ -45,7 +45,7 @@ spec:
         value: "true"
         effect: NoSchedule
       containers:
-        - image: appscode/ccm-linode:external
+        - image: pharmer/ccm-linode:v0.1.1
           imagePullPolicy: Always
           name: ccm-linode
           args:

--- a/addons/csi-linode-v0.0.1.yaml
+++ b/addons/csi-linode-v0.0.1.yaml
@@ -1,0 +1,401 @@
+# Configuration to deploy release version of the CSI Linode
+# plugin (https://github.com/displague/csi-linode) compatible with
+# Kubernetes >=v1.10
+#
+# example usage: kubectl create -f <this_file>
+
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: linode-block-storage
+  namespace: kube-system
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: com.linode.csi.linodebs
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-attacher
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-attacher-runner
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "create"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-attacher-role
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: csi-attacher
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: external-attacher-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+# needed for StatefulSet
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-attacher-linodeplugin
+  namespace: kube-system
+  labels:
+    app: csi-attacher-linodeplugin
+spec:
+  selector:
+    app: csi-attacher-linodeplugin
+  ports:
+    - name: dummy
+      port: 12345
+---
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: csi-attacher-linodeplugin
+  namespace: kube-system
+spec:
+  serviceName: "csi-attacher-linodeplugin"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: csi-attacher-linodeplugin
+    spec:
+      serviceAccount: csi-attacher
+      containers:
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v0.2.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "Always"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: linode-csi-plugin
+          image: displague/linode-csi-plugin:v0.0.1
+          args :
+            - init
+            - "--region=$(LINODE_REGION)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--token=$(LINODE_TOKEN)"
+            - "--url=$(LINODE_API_URL)"
+            - "--node=$(NODE_NAME)"
+            - "--v=10"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: LINODE_API_URL
+              value: https://api.linode.com/v4
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: LINODE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: linode
+                  key: token
+            - name: LINODE_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: linode
+                  key: region
+          imagePullPolicy: "Always"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-provisioner
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-provisioner-runner
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+    
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-role
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: csi-provisioner
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: external-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+# needed for StatefulSet
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-provisioner-linodeplugin
+  namespace: kube-system
+  labels:
+    app: csi-provisioner-linodeplugin
+spec:
+  selector:
+    app: csi-provisioner-linodeplugin
+  ports:
+    - name: dummy
+      port: 12345
+---
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: csi-provisioner-linodeplugin
+  namespace: kube-system
+spec:
+  serviceName: "csi-provisioner-linodeplugin"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: csi-provisioner-linodeplugin
+    spec:
+      serviceAccount: csi-provisioner
+      containers:
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v0.2.0
+          args:
+            - "--provisioner=com.linode.csi.linodebs"
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "Always"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: linode-csi-plugin
+          image: displague/linode-csi-plugin:v0.0.1
+          args :
+            - init
+            - "--region=$(LINODE_REGION)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--token=$(LINODE_TOKEN)"
+            - "--url=$(LINODE_API_URL)"
+            - "--node=$(NODE_NAME)"
+            - "--v=10"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: LINODE_API_URL
+              value: https://api.linode.com/v4
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: LINODE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: linode
+                  key: token
+            - name: LINODE_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: linode
+                  key: region
+          imagePullPolicy: "Always"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-linodeplugin
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-linodeplugin
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "create"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-linodeplugin
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: csi-linodeplugin
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-linodeplugin
+  apiGroup: rbac.authorization.k8s.io          
+
+---
+kind: DaemonSet
+apiVersion: apps/v1beta2
+metadata:
+  name: csi-linodeplugin
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: csi-linodeplugin
+  template:
+    metadata:
+      labels:
+        app: csi-linodeplugin
+    spec:
+      serviceAccount: csi-linodeplugin
+      hostNetwork: true
+      containers:
+        - name: driver-registrar
+          image: quay.io/k8scsi/driver-registrar:v0.2.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi/
+              # TODO(displague): the registrar is not implemented yet
+              # - name: registrar-socket-dir
+              #   mountPath: /var/lib/csi/sockets/
+        - name: csi-linodeplugin 
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: displague/linode-csi-plugin:v0.0.1
+          args :
+            - init
+            - "--region=$(LINODE_REGION)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--token=$(LINODE_TOKEN)"
+            - "--url=$(LINODE_API_URL)"
+            - "--node=$(NODE_NAME)"
+            - "--v=10"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: LINODE_API_URL
+              value: https://api.linode.com/v4
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: LINODE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: linode
+                  key: token
+            - name: LINODE_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: linode
+                  key: region
+          imagePullPolicy: "Always"
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet
+              # needed so that any mounts setup inside this container are
+              # propagated back to the host machine.
+              mountPropagation: "Bidirectional"
+            - mountPath: /dev
+              name: device-dir
+      volumes:
+        # TODO(displague): the registar is not implemented yet
+        #- name: registrar-socket-dir
+        #  hostPath:
+        #    path: /var/lib/kubelet/device-plugins/
+        #    type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/com.linode.csi.linodebs
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev

--- a/addons/external-dns.yaml
+++ b/addons/external-dns.yaml
@@ -38,6 +38,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: external-dns
+  namespace: kube-system
 spec:
   strategy:
     type: Recreate

--- a/addons/external-dns.yaml
+++ b/addons/external-dns.yaml
@@ -32,7 +32,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: external-dns
-  namespace: default
+  namespace: kube-system
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -56,4 +56,7 @@ spec:
         # - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
         env:
         - name: LINODE_TOKEN
-          value: "$(LINODE_TOKEN)"
+          valueFrom:
+            secretKeyRef:
+              name: linode
+              key: token

--- a/addons/external-dns.yaml
+++ b/addons/external-dns.yaml
@@ -2,11 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: external-dns
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: external-dns
+  namespace: kube-system
 rules:
 - apiGroups: [""]
   resources: ["services"]
@@ -25,6 +27,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: external-dns-viewer
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/addons/external-dns.yaml
+++ b/addons/external-dns.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions"]
+  resources: ["ingresses"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: default
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        args:
+        - --source=service # ingress is also possible
+        - --provider=linode
+        # - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
+        env:
+        - name: LINODE_TOKEN
+          value: "$(LINODE_TOKEN)"

--- a/addons/linode-token.yaml
+++ b/addons/linode-token.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: linode
+  namespace: kube-system
+stringData:
+  token: "$(LINODE_TOKEN)"
+  region: "$(LINODE_REGION)"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "linode" {
-  version = "0.0.1"
+  token = "${var.linode_token}"
 }
 
 provider "external" {

--- a/master.tf
+++ b/master.tf
@@ -58,6 +58,7 @@ resource "linode_instance" "k8s_master" {
       "mkdir -p $HOME/.kube && sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config && sudo chown core $HOME/.kube/config",
       "export PATH=$${PATH}:/opt/bin",
       "kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.10.0/Documentation/kube-flannel.yml",
+      "chmod +x /tmp/linode-addons.sh && /tmp/linode-addons.sh ${self.region} ${var.linode_token}",
       "chmod +x /tmp/monitoring-install.sh && /tmp/monitoring-install.sh",
       "chmod +x /tmp/end.sh && sudo /tmp/end.sh",
     ]

--- a/scripts/linode-addons.sh
+++ b/scripts/linode-addons.sh
@@ -10,6 +10,9 @@ sed -i -E \
 	-e 's/\$\(LINODE_TOKEN\)/'$LINODE_TOKEN'/g' \
 	/tmp/linode-token.yaml
 
+# TODO permissions? overwrite prevention?
+echo '{"token": "'${LINODE_TOKEN}'", "zone": "'${LINODE_REGION}'"}' | sudo tee /etc/kubernetes/cloud-config > /dev/null
+
 # TODO swap these for helm charts
 # TODO remove the secrets from /tmp/
 for yaml in \

--- a/scripts/linode-addons.sh
+++ b/scripts/linode-addons.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+LINODE_REGION="$1"
+LINODE_TOKEN="$2"
+
+sed -i -E \
+	-e 's/\$\(LINODE_REGION\)/'$LINODE_REGION'/g' \
+	-e 's/\$\(LINODE_TOKEN\)/'$LINODE_TOKEN'/g' \
+	/tmp/linode-token.yaml
+
+# TODO swap these for helm charts
+# TODO remove the secrets from /tmp/
+for yaml in \
+	linode-token.yaml \
+	ccm-linode.yaml \
+	csi-linode-v0.0.1.yaml \
+	external-dns.yaml \
+; do kubectl apply -f /tmp/${yaml}; done

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,11 @@ variable "nodes" {
   default = 1
 }
 
+variable "linode_token" {
+  type        = "string"
+  description = "Linode API v4 Personal Access Token"
+}
+
 variable "linode_group" {
   default = "k8-terraform-test"
 }


### PR DESCRIPTION
- Closes #5 
- Closes #6 
- Closes #7 

### Test CCM
#### Node Type and Region
```
kubectl describe foo-master-1 # look for annotations..
kubectl describe foor-node-1 # look for annotations..
#  TODO which annotations..
# TODO provide a get -template command to verify against 
```

#### LoadBalancer Support
```
kubectl create deployment --restart=Never --image=gcr.io/kuar-demo/kuard-amd64:1 kuard
kubectl expose --type LoadBalancer --port 8080 deployment kuard
kubectl get services 
# wait for loadbalancer IP, visit it at :8080
```


### Test CSI

https://github.com/displague/csi-linode#create-a-persistentvolumeclaim

### Test External DNS

https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/linode.md#deploying-an-nginx-service
TODO: annotate the nginx in the CCM test for external-dns or avoid conflating tests