### PR TITLE
Variable disk size

### DIFF
--- a/master.tf
+++ b/master.tf
@@ -12,7 +12,7 @@ resource "linode_instance" "k8s_master" {
 
   disk {
     label           = "boot"
-    size            = "${data.linode_instance_type.master.disk}"
+    size            = "${var.disk_size_master > 8191 ? var.disk_size_master : data.linode_instance_type.master.disk}"
     authorized_keys = ["${chomp(file(var.ssh_public_key))}"]
     image           = "linode/containerlinux"
   }

--- a/nodes.tf
+++ b/nodes.tf
@@ -12,7 +12,7 @@ resource "linode_instance" "k8s_node" {
 
   disk {
     label           = "boot"
-    size            = "${data.linode_instance_type.node.disk}"
+    size            = "${var.disk_size_node > 8191 ? var.disk_size_node : data.linode_instance_type.master.disk}"
     authorized_keys = ["${chomp(file(var.ssh_public_key))}"]
     image           = "linode/containerlinux"
   }

--- a/nodes.tf
+++ b/nodes.tf
@@ -12,7 +12,7 @@ resource "linode_instance" "k8s_node" {
 
   disk {
     label           = "boot"
-    size            = "${var.disk_size_node > 8191 ? var.disk_size_node : data.linode_instance_type.master.disk}"
+    size            = "${var.disk_size_node > 8191 ? var.disk_size_node : data.linode_instance_type.node.disk}"
     authorized_keys = ["${chomp(file(var.ssh_public_key))}"]
     image           = "linode/containerlinux"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,16 @@ variable "server_type_node" {
   description = "Values: g6-standard-2 g6-standard-4"
 }
 
+variable "disk_size_master" {
+  default     = 0
+  description = "Min: 8192, size of master server disk in MB"
+}
+
+variable "disk_size_node" {
+  default     = 0
+  description = "Min: 8192, size of node server disk in MB"
+}
+
 variable "nodes" {
   default = 1
 }


### PR DESCRIPTION
### General:

Add variables to enable the override of default disk sizes for master and node servers. 

disk_size_master, disk_size_node - minimum value 8192
If the variable is set less than 8192 the setting is ignored. 



