### PR TITLE
k8s 1.14 support

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -15,7 +15,8 @@ module "linode_k8s" {
   #
   # Or download a tagged releases
   source = "linode/k8s/linode"
-  version      = "0.1.0"
+
+  version = "0.1.0"
 
   nodes        = "${var.nodes}"
   linode_token = "${var.linode_token}"

--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,7 @@ module "masters" {
   linode_token = "${var.linode_token}"
 
   k8s_version       = "${var.k8s_version}"
+  crictl_version    = "${var.crictl_version}"
   k8s_feature_gates = "${var.k8s_feature_gates}"
   cni_version       = "${var.cni_version}"
   ssh_public_key    = "${var.ssh_public_key}"
@@ -45,6 +46,7 @@ module "nodes" {
   node_type    = "${var.server_type_node}"
 
   k8s_version          = "${var.k8s_version}"
+  crictl_version       = "${var.crictl_version}"
   k8s_feature_gates    = "${var.k8s_feature_gates}"
   cni_version          = "${var.cni_version}"
   ssh_public_key       = "${var.ssh_public_key}"

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -44,7 +44,7 @@ resource "linode_instance" "instance" {
       "set -e",
       "chmod +x /tmp/start.sh && sudo /tmp/start.sh",
       "chmod +x /tmp/linode-network.sh && sudo /tmp/linode-network.sh ${self.private_ip_address} ${self.label}",
-      "chmod +x /tmp/kubeadm-install.sh && sudo /tmp/kubeadm-install.sh ${var.k8s_version} ${var.cni_version} ${self.label} ${var.use_public ? self.ip_address : self.private_ip_address} ${var.k8s_feature_gates}",
+      "chmod +x /tmp/kubeadm-install.sh && sudo /tmp/kubeadm-install.sh ${var.k8s_version} ${var.cni_version} ${var.crictl_version} ${self.label} ${var.use_public ? self.ip_address : self.private_ip_address} ${var.k8s_feature_gates}",
     ]
 
     connection {

--- a/modules/instances/scripts/kubeadm-install.sh
+++ b/modules/instances/scripts/kubeadm-install.sh
@@ -3,9 +3,10 @@ set -o nounset -o errexit
 
 K8S_VERSION=$1
 CNI_VERSION=$2
-HOSTNAME=$3
-NODE_IP=$4
-K8S_FEATURE_GATES="$5"
+CRICTL_VERSION="$3"
+HOSTNAME=$4
+NODE_IP=$5
+K8S_FEATURE_GATES="$6"
 
 cat << EOF > /etc/default/kubelet
 KUBELET_EXTRA_ARGS="--cloud-provider=external --allow-privileged=true --feature-gates=${K8S_FEATURE_GATES}"
@@ -32,7 +33,6 @@ mkdir -p /etc/kubernetes/manifests
 mkdir -p /opt/cni/bin
 curl -L 2>/dev/null "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
 
-CRICTL_VERSION="v1.12.0"
 mkdir -p /opt/bin
 curl -L 2>/dev/null "https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz
 

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -47,6 +47,10 @@ variable "k8s_version" {
   description = "Kubernetes version to install"
 }
 
+variable "crictl_version" {
+  description = "Contrainer Runtime Interface version to install"
+}
+
 variable "k8s_feature_gates" {
   description = "Feature gates to enable in the Kubelet and API server"
 }

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -48,7 +48,7 @@ variable "k8s_version" {
 }
 
 variable "crictl_version" {
-  description = "Contrainer Runtime Interface version to install"
+  description = "Container Runtime Interface version to install"
 }
 
 variable "k8s_feature_gates" {

--- a/modules/masters/main.tf
+++ b/modules/masters/main.tf
@@ -11,6 +11,7 @@ module "master_instance" {
   k8s_version       = "${var.k8s_version}"
   k8s_feature_gates = "${var.k8s_feature_gates}"
   cni_version       = "${var.cni_version}"
+  crictl_version    = "${var.crictl_version}"
   ssh_public_key    = "${var.ssh_public_key}"
   region            = "${var.region}"
 }

--- a/modules/masters/manifests/csi-linode.yaml
+++ b/modules/masters/manifests/csi-linode.yaml
@@ -285,8 +285,16 @@ metadata:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: linodebs.csi.linode.com
 ---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: linode-block-storage-retain
+  namespace: kube-system
+provisioner: linodebs.csi.linode.com
+reclaimPolicy: Retain
+
+---
 # pkg/linode-bs/deploy/kubernetes/06-ss-csi-linode-controller.yaml
-# stateful sets needs a headless service to provide pod network indentity
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
@@ -309,7 +317,8 @@ spec:
         - name: csi-provisioner
           image: quay.io/k8scsi/csi-provisioner:v1.0.0
           args:
-            - "--provisioner=linodebs.csi.linode.com"
+            - "--volume-name-prefix=pvc"
+            - "--volume-name-uuid-length=16"
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
           env:
@@ -332,18 +341,21 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: linode-csi-plugin
-          image: linode/linode-blockstorage-csi-driver:canary
+          image: linode/linode-blockstorage-csi-driver:v0.1.0
           args :
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--token=$(LINODE_TOKEN)"
             - "--url=$(LINODE_API_URL)"
             - "--node=$(NODE_NAME)"
+            - "--bs-prefix=$(LINODE_BS_PREFIX)"
             - "--v=10"
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: LINODE_API_URL
               value: https://api.linode.com/v4
+            - name: LINODE_BS_PREFIX
+              value:
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -360,6 +372,7 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
+
 ---
 # pkg/linode-bs/deploy/kubernetes/07-ds-csi-linode-node.yaml
 kind: DaemonSet
@@ -404,7 +417,7 @@ spec:
             - name: registration-dir
               mountPath: /registration/
         - name: csi-linode-plugin 
-          image: linode/linode-blockstorage-csi-driver:canary
+          image: linode/linode-blockstorage-csi-driver:v0.1.0
           args :
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--token=$(LINODE_TOKEN)"
@@ -478,4 +491,5 @@ spec:
           hostPath:
             path: /sys
             type: Directory
+
 ---

--- a/modules/masters/scripts/local/kubeadm-token.sh
+++ b/modules/masters/scripts/local/kubeadm-token.sh
@@ -11,7 +11,7 @@ if [ -z "$HOST" ]; then
   echo "{\"command\":\"\"}"
 else
   CMD=$(ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-    core@$HOST sudo kubeadm token create --print-join-command)
+    core@$HOST sudo kubeadm token create --print-join-command | awk '/kubeadm/ && ! /control-plane/ {gsub(/^[ \t]/, "", $0); print $0}' )
   # Produce a JSON object containing the join command
   echo "{\"command\":\"$CMD\"}"
 fi

--- a/modules/masters/scripts/local/kubeadm-token.sh
+++ b/modules/masters/scripts/local/kubeadm-token.sh
@@ -11,7 +11,8 @@ if [ -z "$HOST" ]; then
   echo "{\"command\":\"\"}"
 else
   CMD=$(ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-    core@$HOST sudo kubeadm token create --print-join-command | awk '/kubeadm/ && ! /control-plane/ {gsub(/^[ \t]/, "", $0); print $0}' )
+    core@$HOST sudo kubeadm token create --print-join-command | awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next }; /kubeadm/ && ! /control-plane/ {gsub(/^[ \t]/, "", $0); print $0}' )
   # Produce a JSON object containing the join command
-  echo "{\"command\":\"$CMD\"}"
+  CMD="$CMD --discovery-token-unsafe-skip-ca-verification"
+  echo '{"command":"'"${CMD}"'"}'
 fi

--- a/modules/masters/variables.tf
+++ b/modules/masters/variables.tf
@@ -35,6 +35,10 @@ variable "cni_version" {
   description = "Container Network Plugin Version"
 }
 
+variable "crictl_version" {
+  description = "Contrainer Runtime Interface version to install"
+}
+
 variable "cluster_name" {
   description = "Name of the Kubernetes cluster"
 }

--- a/modules/masters/variables.tf
+++ b/modules/masters/variables.tf
@@ -36,7 +36,7 @@ variable "cni_version" {
 }
 
 variable "crictl_version" {
-  description = "Contrainer Runtime Interface version to install"
+  description = "Container Runtime Interface version to install"
 }
 
 variable "cluster_name" {

--- a/modules/nodes/main.tf
+++ b/modules/nodes/main.tf
@@ -13,6 +13,7 @@ module "node" {
   k8s_version       = "${var.k8s_version}"
   k8s_feature_gates = "${var.k8s_feature_gates}"
   cni_version       = "${var.cni_version}"
+  crictl_version    = "${var.crictl_version}"
 }
 
 // todo: does the use of var.kubeadm_join_command (from master output)  queue nodes behind masters? move to parent main.tf if so

--- a/modules/nodes/variables.tf
+++ b/modules/nodes/variables.tf
@@ -48,6 +48,10 @@ variable "cni_version" {
   description = "CNI version to install"
 }
 
+variable "crictl_version" {
+  description = "Contrainer Runtime Interface version to install"
+}
+
 variable "k8s_feature_gates" {
   description = "Kubernetes Feature gates to enable in the Kubelet"
 }

--- a/modules/nodes/variables.tf
+++ b/modules/nodes/variables.tf
@@ -49,7 +49,7 @@ variable "cni_version" {
 }
 
 variable "crictl_version" {
-  description = "Contrainer Runtime Interface version to install"
+  description = "Container Runtime Interface version to install"
 }
 
 variable "k8s_feature_gates" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,8 @@ output "k8s_master_public_ip" {
 }
 
 output "kubeadm_join_command" {
-  value = "${module.masters.kubeadm_join_command}"
+  value     = "${module.masters.kubeadm_join_command}"
+  sensitive = true
 }
 
 output "nodes_public_ip" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "k8s_version" {
   description = "Kubernetes version to install"
 }
 
+variable "crictl_version" {
+  default     = "v1.12.0"
+  description = "Container Runtime Interface version to install"
+}
+
 variable "k8s_feature_gates" {
   default     = "CSINodeInfo=true,CSIDriverRegistry=true,BlockVolume=true,CSIBlockVolume=true"
   description = "Feature gates to enable in the Kubelet and API server"

--- a/variables.tf
+++ b/variables.tf
@@ -4,12 +4,12 @@ variable "cni_version" {
 }
 
 variable "k8s_version" {
-  default     = "v1.13.2"
+  default     = "v1.13.4"
   description = "Kubernetes version to install"
 }
 
 variable "crictl_version" {
-  default     = "v1.12.0"
+  default     = "v1.13.0"
   description = "Container Runtime Interface version to install"
 }
 


### PR DESCRIPTION
This PR prepares `terraform-linode-k8s` for Kubernetes 1.14.0.

Changes include:
* Kubernetes version updated to `1.13.4` (not `1.14.0`, which has not yet been released)
* `crictl` version is configurable (and updated to `1.13.0` (_latest_)*
* `join` command parsing and reformatting (only needed by `1.14.0-beta*` and `1.14.0-rc*`)
* `join` command suffixing for new required option: `--discovery-token-unsafe-skip-ca-verification`
  * This parameter is *not compatible* with versions < ~`1.14.0`~ `1.8.0`
  * This parameter could be avoided if the CA was known on the nodes
* `join` token is now a sensitive output variable