### PR TITLE
add traefik as the default ingress

### DIFF
--- a/modules/instances/scripts/ingress-install.sh
+++ b/modules/instances/scripts/ingress-install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+# TODO swap these for helm charts
+
+kubectl apply -f /tmp/traefik-ds.yaml

--- a/modules/instances/scripts/ingress-install.sh
+++ b/modules/instances/scripts/ingress-install.sh
@@ -4,4 +4,5 @@ set -e
 
 # TODO swap these for helm charts
 
+kubectl apply -f /tmp/traefik-traefik.yaml
 kubectl apply -f /tmp/traefik-ds.yaml

--- a/modules/instances/scripts/ingress-install.sh
+++ b/modules/instances/scripts/ingress-install.sh
@@ -4,5 +4,5 @@ set -e
 
 # TODO swap these for helm charts
 
-kubectl apply -f /tmp/traefik-traefik.yaml
-kubectl apply -f /tmp/traefik-ds.yaml
+kubectl apply -f /home/core/init/traefik-traefik.yaml
+kubectl apply -f /home/core/init/traefik-ds.yaml

--- a/modules/masters/main.tf
+++ b/modules/masters/main.tf
@@ -39,6 +39,7 @@ resource "null_resource" "masters_provisioner" {
       "kubectl apply -f /tmp/calico.yaml",
       "chmod +x /tmp/linode-addons.sh && /tmp/linode-addons.sh ${var.region} ${var.linode_token}",
       "chmod +x /tmp/monitoring-install.sh && /tmp/monitoring-install.sh",
+      "chmod +x /tmp/ingress-install.sh && /tmp/ingress-install.sh",
       "chmod +x /tmp/end.sh && sudo /tmp/end.sh",
     ]
 

--- a/modules/masters/manifests/traefik-ds.yaml
+++ b/modules/masters/manifests/traefik-ds.yaml
@@ -1,0 +1,59 @@
+# xref: https://raw.githubusercontent.com/containous/traefik/v1.7/examples/k8s/traefik-ds.yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: traefik-ingress-controller
+  namespace: kube-system
+---
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: traefik-ingress-controller
+  namespace: kube-system
+  labels:
+    k8s-app: traefik-ingress-lb
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: traefik-ingress-lb
+        name: traefik-ingress-lb
+    spec:
+      serviceAccountName: traefik-ingress-controller
+      terminationGracePeriodSeconds: 60
+      containers:
+      - image: traefik
+        name: traefik-ingress-lb
+        ports:
+        - name: http
+          containerPort: 80
+          hostPort: 80
+        - name: admin
+          containerPort: 8080
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_BIND_SERVICE
+        args:
+        - --api
+        - --kubernetes
+        - --logLevel=INFO
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: traefik-ingress-service
+  namespace: kube-system
+spec:
+  selector:
+    k8s-app: traefik-ingress-lb
+  ports:
+    - protocol: TCP
+      port: 80
+      name: web
+    - protocol: TCP
+      port: 8080
+      name: admin

--- a/modules/masters/manifests/traefik-rbac.yaml
+++ b/modules/masters/manifests/traefik-rbac.yaml
@@ -1,0 +1,44 @@
+# xref: https://raw.githubusercontent.com/containous/traefik/v1.7/examples/k8s/traefik-rbac.yaml
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: traefik-ingress-controller
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - ingresses/status
+    verbs:
+    - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: traefik-ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: traefik-ingress-controller
+subjects:
+- kind: ServiceAccount
+  name: traefik-ingress-controller
+  namespace: kube-system


### PR DESCRIPTION
This introduces Traefik as the default ingress, running as a DaemonSet listening on Port 80/8080 of the nodes.
* https://docs.traefik.io/user-guide/kubernetes/

Is traefik the best choice? 
* https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/#additional-controllers

Should this listen on port 443 too?

Borrowing from kube-linode, other ideas to consider:
* https://github.com/kahkhang/kube-linode/blob/master/manifests/traefik.yaml#L58-L59
  this sets up a secret for the traefik control panel and configures an ingress for it





