### PR TITLE
update kubernetes and crictl versions to v1.14.0

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -4,12 +4,12 @@ variable "cni_version" {
 }
 
 variable "k8s_version" {
-  default     = "v1.13.4"
+  default     = "v1.14.0"
   description = "Kubernetes version to install"
 }
 
 variable "crictl_version" {
-  default     = "v1.13.0"
+  default     = "v1.14.0"
   description = "Container Runtime Interface version to install"
 }
 


### PR DESCRIPTION
This PR update the Kubernetes and crictl versions to v1.14.0.