### PR TITLE
added python check

### DIFF
--- a/scripts/local/preflight.sh
+++ b/scripts/local/preflight.sh
@@ -10,4 +10,4 @@ function assertInstalled() {
     done
 }
 
-assertInstalled ssh scp sed kubectl
+assertInstalled ssh scp sed kubectl python


### PR DESCRIPTION
#### No python installed on local breaks the kubeadm_join, kubeadm-token.sh ####

```
module.nodes.null_resource.kubeadm_join[2] (remote-exec): usage: sudo -h | -K | -k | -V
module.nodes.null_resource.kubeadm_join[2] (remote-exec): usage: sudo -v [-AknS] [-g group] [-h
module.nodes.null_resource.kubeadm_join[1] (remote-exec): usage: sudo -h | -K | -k | -V
module.nodes.null_resource.kubeadm_join[1] (remote-exec): usage: sudo -v [-AknS] [-g group] [-h
module.nodes.null_resource.kubeadm_join[0] (remote-exec): usage: sudo -h | -K | -k | -V
module.nodes.null_resource.kubeadm_join[0] (remote-exec): usage: sudo -v [-AknS] [-g group] [-h

module.nodes.null_resource.kubeadm_join[1] (remote-exec):  host] [-p prompt] [-u user]
module.nodes.null_resource.kubeadm_join[1] (remote-exec): usage: sudo -l [-AknS] [-g group] [-h
module.nodes.null_resource.kubeadm_join[1] (remote-exec):             host] [-p prompt] [-U user]
module.nodes.null_resource.kubeadm_join[1] (remote-exec):             [-u user] [command]
module.nodes.null_resource.kubeadm_join[1] (remote-exec): usage: sudo [-AbEHknPS] [-C num] [-g
module.nodes.null_resource.kubeadm_join[1] (remote-exec):             group] [-h host] [-p
module.nodes.null_resource.kubeadm_join[1] (remote-exec):             prompt] [-T timeout] [-u
module.nodes.null_resource.kubeadm_join[1] (remote-exec):             user] [VAR=value] [-i|-s]
module.nodes.null_resource.kubeadm_join[1] (remote-exec):             [<command>]
module.nodes.null_resource.kubeadm_join[1] (remote-exec): usage: sudo -e [-AknS] [-C num] [-g
module.nodes.null_resource.kubeadm_join[1] (remote-exec):             group] [-h host] [-p
module.nodes.null_resource.kubeadm_join[1] (remote-exec):             prompt] [-T timeout] [-u

module.nodes.null_resource.kubeadm_join[0] (remote-exec):        host] [-p prompt] [-u user]
module.nodes.null_resource.kubeadm_join[0] (remote-exec): usage: sudo -l [-AknS] [-g group] [-h
module.nodes.null_resource.kubeadm_join[0] (remote-exec):             host] [-p prompt] [-U user]
module.nodes.null_resource.kubeadm_join[0] (remote-exec):             [-u user] [command]
module.nodes.null_resource.kubeadm_join[0] (remote-exec): usage: sudo [-AbEHknPS] [-C num] [-g
module.nodes.null_resource.kubeadm_join[0] (remote-exec):             group] [-h host] [-p
module.nodes.null_resource.kubeadm_join[0] (remote-exec):             prompt] [-T timeout] [-u
module.nodes.null_resource.kubeadm_join[0] (remote-exec):             user] [VAR=value] [-i|-s]
module.nodes.null_resource.kubeadm_join[0] (remote-exec):             [<command>]
module.nodes.null_resource.kubeadm_join[0] (remote-exec): usage: sudo -e [-AknS] [-C num] [-g
module.nodes.null_resource.kubeadm_join[0] (remote-exec):             group] [-h host] [-p
module.nodes.null_resource.kubeadm_join[0] (remote-exec):             prompt] [-T timeout] [-u
module.nodes.null_resource.kubeadm_join[0] (remote-exec):             user] file ...

Error: Error applying plan:

3 error(s) occurred:

* module.nodes.null_resource.kubeadm_join[1]: error executing "/tmp/terraform_1529647733.sh": Process exited with status 1
* module.nodes.null_resource.kubeadm_join[0]: error executing "/tmp/terraform_382097516.sh": Process exited with status 1
* module.nodes.null_resource.kubeadm_join[2]: error executing "/tmp/terraform_823746292.sh": Process exited with status 1
```
#### Added check in preflight.sh for easier debug ####

```
module.nodes.null_resource.kubeadm_join[1] (remote-exec): usage: sudo -h | -K | -k | -V
module.nodes.null_resource.kubeadm_join[1] (remote-exec): usage: sudo -v [-AknS] [-g group] [-h
module.nodes.null_resource.kubeadm_join[1] (remote-exec):             host] [-p prompt] [-u user]
module.nodes.null_resource.kubeadm_join[1] (remote-exec): usage: sudo -l [-AknS] [-g group] [-h
module.nodes.null_resource.kubeadm_join[1] (remote-exec):             host] [-p prompt] [-U user]

module.nodes.null_resource.kubeadm_join[1] (remote-exec):         [-u user] [command]
module.nodes.null_resource.kubeadm_join[1] (remote-exec): usage: sudo [-AbEHknPS] [-C num] [-g
module.nodes.null_resource.kubeadm_join[1] (remote-exec):             group] [-h host] [-p
module.nodes.null_resource.kubeadm_join[1] (remote-exec):             prompt] [-T timeout] [-u
module.nodes.null_resource.kubeadm_join[1] (remote-exec):             user] [VAR=value] [-i|-s]
module.nodes.null_resource.kubeadm_join[1] (remote-exec):             [<command>]
module.nodes.null_resource.kubeadm_join[1] (remote-exec): usage: sudo -e [-AknS] [-C num] [-g
module.nodes.null_resource.kubeadm_join[0] (remote-exec): usage: sudo -h | -K | -k | -V
module.nodes.null_resource.kubeadm_join[0] (remote-exec): usage: sudo -v [-AknS] [-g group] [-h

module.nodes.null_resource.kubeadm_join[2] (remote-exec): usage: sudo -h | -K | -k | -V
module.nodes.null_resource.kubeadm_join[2] (remote-exec): usage: sudo -v [-AknS] [-g group] [-h
module.nodes.null_resource.kubeadm_join[2] (remote-exec):             host] [-p prompt] [-u user]
module.nodes.null_resource.kubeadm_join[0] (remote-exec):        host] [-p prompt] [-u user]
module.nodes.null_resource.kubeadm_join[0] (remote-exec): usage: sudo -l [-AknS] [-g group] [-h
module.nodes.null_resource.kubeadm_join[0] (remote-exec):             host] [-p prompt] [-U user]
module.nodes.null_resource.kubeadm_join[0] (remote-exec):             [-u user] [command]
module.nodes.null_resource.kubeadm_join[0] (remote-exec): usage: sudo [-AbEHknPS] [-C num] [-g
module.nodes.null_resource.kubeadm_join[0] (remote-exec):             group] [-h host] [-p
module.nodes.null_resource.kubeadm_join[0] (remote-exec):             prompt] [-T timeout] [-u
module.nodes.null_resource.kubeadm_join[0] (remote-exec):             user] [VAR=value] [-i|-s]
module.nodes.null_resource.kubeadm_join[0] (remote-exec):             [<command>]
module.nodes.null_resource.kubeadm_join[0] (remote-exec): usage: sudo -e [-AknS] [-C num] [-g
module.nodes.null_resource.kubeadm_join[2] (remote-exec): usage: sudo -l [-AknS] [-g group] [-h

module.nodes.null_resource.kubeadm_join[2] (remote-exec):             host] [-p prompt] [-U user]
module.nodes.null_resource.kubeadm_join[2] (remote-exec):             [-u user] [command]
module.nodes.null_resource.kubeadm_join[2] (remote-exec): usage: sudo [-AbEHknPS] [-C num] [-g
module.nodes.null_resource.kubeadm_join[2] (remote-exec):             group] [-h host] [-p
module.nodes.null_resource.kubeadm_join[2] (remote-exec):             prompt] [-T timeout] [-u
module.nodes.null_resource.kubeadm_join[2] (remote-exec):             user] [VAR=value] [-i|-s]
module.nodes.null_resource.kubeadm_join[2] (remote-exec):             [<command>]
module.nodes.null_resource.kubeadm_join[2] (remote-exec): usage: sudo -e [-AknS] [-C num] [-g
module.nodes.null_resource.kubeadm_join[2] (remote-exec):             group] [-h host] [-p
module.nodes.null_resource.kubeadm_join[2] (remote-exec):             prompt] [-T timeout] [-u
module.nodes.null_resource.kubeadm_join[2] (remote-exec):             user] file ...

Error: Error applying plan:

4 error(s) occurred:

* module.nodes.null_resource.kubeadm_join[1]: error executing "/tmp/terraform_531853108.sh": Process exited with status 1
* module.nodes.null_resource.kubeadm_join[0]: error executing "/tmp/terraform_289423432.sh": Process exited with status 1
* module.nodes.null_resource.kubeadm_join[2]: error executing "/tmp/terraform_1658642843.sh": Process exited with status 1
* null_resource.preflight-checks: Error running command '/home/afarris/git/terraform-linode-k8s/scripts/local/preflight.sh': exit status 1. Output: python not found

```
**null_resource.preflight-checks: Error running command '/home/afarris/git/terraform-linode-k8s/scripts/local/preflight.sh': exit status 1. Output: python not found**

