### PR TITLE
explicitly set leader-elect resource lock endpoints

### DIFF
--- a/modules/masters/templates/ccm-linode.yaml.template
+++ b/modules/masters/templates/ccm-linode.yaml.template
@@ -62,6 +62,7 @@ spec:
           name: ccm-linode
           args:
           - --cloud-provider=linode
+          - --leader-elect-resource-lock=endpoints
           - --v=3
           volumeMounts:
           - mountPath: /etc/kubernetes


### PR DESCRIPTION
Since Kubernetes 1.17, the default value of `leader-elect-resource-lock`
has been endpointsleases. Now that linode-cloud-controller-manager's
Kubernetes components are being updated, it's necessary to explicitly set
endpoints as the resource lock.



